### PR TITLE
Add website extension status handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 This repo is for docs, bugs, and suggestions for the Community Archive Stream browser extension, which intercepts some tweets as you view them and adds them to the [Twitter Community Archive](http://community-archive.org/) open database
 
-Install it here:
-
-[TBD]
-
+Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk).
 
 This is a [Plasmo extension](https://docs.plasmo.com/) project bootstrapped with [`plasmo init`](https://www.npmjs.com/package/plasmo).
 
@@ -26,4 +23,3 @@ Open your browser and load the appropriate development build. For example, if yo
 You can start editing the popup by modifying `popup.tsx`. It should auto-update as you make changes. To add an options page, simply add a `options.tsx` file to the root of the project, with a react component default exported. Likewise to add a content page, add a `content.ts` file to the root of the project, importing some module and do some logic, then reload the extension on your browser.
 
 For further guidance, [visit our Documentation](https://docs.plasmo.com/)
-

--- a/background/index.ts
+++ b/background/index.ts
@@ -1,15 +1,18 @@
-import { supabase } from '~core/supabase'
-import { cleanupOldRecords } from '../utils/IndexDB'
+import { supabase } from "~core/supabase"
+
+import { cleanupOldRecords } from "../utils/IndexDB"
 
 // Run database cleanup on extension startup
 async function runDatabaseCleanup() {
   try {
     const deletedRecords = await cleanupOldRecords(7500)
     if (deletedRecords > 0) {
-      console.log(`Database cleanup completed: ${deletedRecords} old records deleted`)
+      console.log(
+        `Database cleanup completed: ${deletedRecords} old records deleted`
+      )
     }
   } catch (error) {
-    console.error('Error running database cleanup:', error)
+    console.error("Error running database cleanup:", error)
   }
 }
 
@@ -17,7 +20,7 @@ async function runDatabaseCleanup() {
 function setupPeriodicCleanup() {
   // Run cleanup immediately on startup
   runDatabaseCleanup()
-  
+
   // Set interval for every 3 hours (3 * 60 * 60 * 1000 ms)
   const THREE_HOURS_MS = 3 * 60 * 60 * 1000
   setInterval(runDatabaseCleanup, THREE_HOURS_MS)
@@ -34,11 +37,46 @@ console.log(
   "Live now; make now always the most precious time. Now will never come again."
 )
 
-
 chrome.runtime.onInstalled.addListener((details) => {
-  if (details.reason === 'install') {
+  if (details.reason === "install") {
     chrome.tabs.create({
-      url: chrome.runtime.getURL('options.html')
-    });
+      url: chrome.runtime.getURL("options.html")
+    })
   }
-});
+})
+
+const EXTENSION_STATUS_REQUEST = "community-archive:extension-status"
+const COMMUNITY_ARCHIVE_HOSTS = new Set([
+  "community-archive.org",
+  "www.community-archive.org",
+  "localhost",
+  "127.0.0.1"
+])
+
+// The website uses this narrow, read-only handshake to avoid showing install
+// suggestions to people who already have the extension. No account, browsing,
+// or archive data is exposed.
+chrome.runtime.onMessageExternal.addListener(
+  (message, sender, sendResponse) => {
+    let senderIsCommunityArchive = false
+    try {
+      senderIsCommunityArchive =
+        typeof sender.url === "string" &&
+        COMMUNITY_ARCHIVE_HOSTS.has(new URL(sender.url).hostname)
+    } catch {
+      senderIsCommunityArchive = false
+    }
+
+    if (
+      !senderIsCommunityArchive ||
+      message?.type !== EXTENSION_STATUS_REQUEST
+    ) {
+      return
+    }
+
+    sendResponse({
+      installed: true,
+      version: chrome.runtime.getManifest().version
+    })
+  }
+)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "community-archive-stream",
   "displayName": "Community Archive Stream",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "An extension to stream data to the community archive as you use Twitter.",
   "author": "IaimforGOAT",
   "scripts": {
@@ -91,6 +91,14 @@
       "https://*.twitter.com/*",
       "https://*.x.com/*"
     ],
+    "externally_connectable": {
+      "matches": [
+        "https://community-archive.org/*",
+        "https://www.community-archive.org/*",
+        "http://localhost/*",
+        "http://127.0.0.1/*"
+      ]
+    },
     "web_accessible_resources": [
       {
         "resources": [


### PR DESCRIPTION
## Summary

- bump the extension to 0.0.4
- allow Community Archive origins to request a narrow, read-only install status
- validate the sender and return only the installed state and extension version
- replace the README placeholder with the Chrome Web Store link

## Why

The Community Archive website is adding contextual install prompts. This handshake lets those prompts stay hidden for people who already have the extension.

## Rollout

Publish version 0.0.4 to the Chrome Web Store before merging the paired website PR. Existing 0.0.3 installations cannot answer the new status request.

## Validation

- `pnpm build`
- verified the generated Chrome MV3 manifest contains version 0.0.4 and the expected `externally_connectable` allowlist
- verified the generated background worker contains the status handler

## Existing repository issue

`pnpm exec tsc --noEmit` still reports unrelated legacy errors in existing dashboard, sign-in, interceptor, and observable code. The production Plasmo build succeeds.
