### PR TITLE
Remove unneeded website status handshake

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -44,39 +44,3 @@ chrome.runtime.onInstalled.addListener((details) => {
     })
   }
 })
-
-const EXTENSION_STATUS_REQUEST = "community-archive:extension-status"
-const COMMUNITY_ARCHIVE_HOSTS = new Set([
-  "community-archive.org",
-  "www.community-archive.org",
-  "localhost",
-  "127.0.0.1"
-])
-
-// The website uses this narrow, read-only handshake to avoid showing install
-// suggestions to people who already have the extension. No account, browsing,
-// or archive data is exposed.
-chrome.runtime.onMessageExternal.addListener(
-  (message, sender, sendResponse) => {
-    let senderIsCommunityArchive = false
-    try {
-      senderIsCommunityArchive =
-        typeof sender.url === "string" &&
-        COMMUNITY_ARCHIVE_HOSTS.has(new URL(sender.url).hostname)
-    } catch {
-      senderIsCommunityArchive = false
-    }
-
-    if (
-      !senderIsCommunityArchive ||
-      message?.type !== EXTENSION_STATUS_REQUEST
-    ) {
-      return
-    }
-
-    sendResponse({
-      installed: true,
-      version: chrome.runtime.getManifest().version
-    })
-  }
-)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "community-archive-stream",
   "displayName": "Community Archive Stream",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "description": "An extension to stream data to the community archive as you use Twitter.",
   "author": "IaimforGOAT",
   "scripts": {
@@ -91,14 +91,6 @@
       "https://*.twitter.com/*",
       "https://*.x.com/*"
     ],
-    "externally_connectable": {
-      "matches": [
-        "https://community-archive.org/*",
-        "https://www.community-archive.org/*",
-        "http://localhost/*",
-        "http://127.0.0.1/*"
-      ]
-    },
     "web_accessible_resources": [
       {
         "resources": [


### PR DESCRIPTION
## Summary

- remove the external website message handler added by PR #5
- remove the now-unused `externally_connectable` manifest entry
- restore the unpublished version number from 0.0.4 to 0.0.3
- retain the useful Chrome Web Store link added to the README

## Why

The published 0.0.3 extension already exposes a stable image as a web-accessible resource. The website can use that resource as a positive installation signal, so a new extension release and messaging surface are unnecessary.

## Paired website change

- [TheExGenesis/community-archive#734](https://github.com/TheExGenesis/community-archive/pull/734)

## Validation

- `pnpm build`
- generated background worker contains no external status handler
- generated manifest remains version 0.0.3 with the existing web-accessible resource
- `git diff --check`

Follow-up to merged PR #5.
